### PR TITLE
fix links to scalaz source

### DIFF
--- a/docs/06/a.md
+++ b/docs/06/a.md
@@ -86,10 +86,10 @@ The following operators are supported by all data types enabled by `import Scala
 trait ToDataOps extends ToIdOps with ToTreeOps with ToWriterOps with ToValidationOps with ToReducerOps with ToKleisliOps
 ```
 
-The operator in question is part of [`WriterV`]($scalazBaseUrl$/core/src/main/scala/scalaz/syntax/WriterOps.scala):
+The operator in question is part of [`WriterOps`]($scalazBaseUrl$/core/src/main/scala/scalaz/syntax/WriterOps.scala):
 
 ```scala
-trait WriterV[A] extends Ops[A] {
+final class WriterOps[A](self: A) {
   def set[W](w: W): Writer[W, A] = WriterT.writer(w -> self)
 
   def tell: Writer[A, Unit] = WriterT.tell(self)

--- a/docs/ja/06/a.md
+++ b/docs/ja/06/a.md
@@ -86,10 +86,10 @@ res46: scalaz.Writer[String,Int] = scalaz.WriterTFunctions\$\$anon\$26@477a0c05
 trait ToDataOps extends ToIdOps with ToTreeOps with ToWriterOps with ToValidationOps with ToReducerOps with ToKleisliOps
 ```
 
-件の演算子は [`WriterV`]($scalazBaseUrl$/core/src/main/scala/scalaz/syntax/ToWriterOps.scala) の一部だ:
+件の演算子は [`WriterOps`]($scalazBaseUrl$/core/src/main/scala/scalaz/syntax/WriterOps.scala) の一部だ:
 
 ```scala
-trait WriterV[A] extends Ops[A] {
+final class WriterOps[A](self: A) {
   def set[W](w: W): Writer[W, A] = WriterT.writer(w -> self)
 
   def tell: Writer[A, Unit] = WriterT.tell(self)


### PR DESCRIPTION
Sorry i didn't check compiled pages because I couldnt find ["pf" command](https://github.com/eed3si9n/learning-scalaz/blob/series/7.1.x/site.sbt#L23).
